### PR TITLE
fix: Replace `direflow-scripts` esm bin bootstrap and validate GitHub Actions on Node 22/24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,20 @@ on:
 
 jobs:
   build:
+    name: build (Node ${{ matrix.node-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 22
+          - 24
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install root dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Determine release version
         id: release
@@ -92,8 +92,15 @@ jobs:
             }
 
   validate:
+    name: validate (Node ${{ matrix.node-version }})
     needs: prepare
     if: needs.prepare.outputs.should_publish == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 22
+          - 24
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -102,7 +109,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: |
             package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kefelan/direflow-cli",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kefelan/direflow-cli",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "boxen": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kefelan/direflow-cli",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Official CLI for Direflow",
   "main": "dist/cli.js",
   "types": "dist/cli.d.ts",

--- a/packages/direflow-component/package-lock.json
+++ b/packages/direflow-component/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kefelan/direflow-component",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kefelan/direflow-component",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",

--- a/packages/direflow-component/package.json
+++ b/packages/direflow-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kefelan/direflow-component",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/direflow-scripts/bin/direflow-scripts
+++ b/packages/direflow-scripts/bin/direflow-scripts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-require = require('esm')(module);
-const cli = require('../dist/cli');
-const [,, ...args] = process.argv;
-cli.default(args);
+const { default: run } = require('../dist/cli');
+
+run(process.argv.slice(2));

--- a/packages/direflow-scripts/package-lock.json
+++ b/packages/direflow-scripts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kefelan/direflow-scripts",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kefelan/direflow-scripts",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.29.0",
@@ -16,7 +16,6 @@
         "babel-loader": "^8.4.1",
         "chalk": "^4.1.2",
         "css-loader": "^6.11.0",
-        "esm": "^3.2.25",
         "event-hooks-webpack-plugin": "^2.2.0",
         "handlebars": "^4.7.7",
         "rimraf": "^3.0.2",
@@ -3019,14 +3018,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/esrecurse": {
@@ -6587,11 +6578,6 @@
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esrecurse": {
       "version": "4.3.0",

--- a/packages/direflow-scripts/package.json
+++ b/packages/direflow-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kefelan/direflow-scripts",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Create Web Components using React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,7 +35,6 @@
     "babel-loader": "^8.4.1",
     "chalk": "^4.1.2",
     "css-loader": "^6.11.0",
-    "esm": "^3.2.25",
     "event-hooks-webpack-plugin": "^2.2.0",
     "handlebars": "^4.7.7",
     "rimraf": "^3.0.2",

--- a/templates/js/package.json
+++ b/templates/js/package.json
@@ -36,8 +36,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-scripts": "^4.0.3",
-    "@kefelan/direflow-component": "5.0.2",
-    "@kefelan/direflow-scripts": "5.0.2"
+    "@kefelan/direflow-component": "5.0.3",
+    "@kefelan/direflow-scripts": "5.0.3"
   },
   "devDependencies": {
     "eslint-plugin-node": "^11.1.0",

--- a/templates/ts/package.json
+++ b/templates/ts/package.json
@@ -40,8 +40,8 @@
     "react-dom": "18.2.0",
     "react-lib-adler32": "^1.0.3",
     "react-scripts": "^4.0.3",
-    "@kefelan/direflow-component": "5.0.2",
-    "@kefelan/direflow-scripts": "5.0.2",
+    "@kefelan/direflow-component": "5.0.3",
+    "@kefelan/direflow-scripts": "5.0.3",
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {

--- a/test/direflowScriptsBin.test.ts
+++ b/test/direflowScriptsBin.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { resolve } from 'path';
+
+describe('direflow-scripts bin launcher', () => {
+  const binPath = resolve(__dirname, '../packages/direflow-scripts/bin/direflow-scripts');
+
+  it('does not bootstrap through esm', () => {
+    const binContents = readFileSync(binPath, 'utf8');
+
+    expect(binContents).not.toContain("require('esm')");
+    expect(binContents).toContain("require('../dist/cli')");
+  });
+
+  it('runs through node without crashing', () => {
+    const result = spawnSync(process.execPath, [binPath, '--help'], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+});

--- a/test/direflowScriptsBin.test.ts
+++ b/test/direflowScriptsBin.test.ts
@@ -1,6 +1,9 @@
-import { readFileSync } from 'fs';
+import {
+  mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync,
+} from 'fs';
 import { spawnSync } from 'child_process';
-import { resolve } from 'path';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 
 describe('direflow-scripts bin launcher', () => {
   const binPath = resolve(__dirname, '../packages/direflow-scripts/bin/direflow-scripts');
@@ -13,9 +16,20 @@ describe('direflow-scripts bin launcher', () => {
   });
 
   it('runs through node without crashing', () => {
-    const result = spawnSync(process.execPath, [binPath, '--help'], {
+    const tempPackagePath = mkdtempSync(join(tmpdir(), 'direflow-scripts-bin-'));
+    const tempBinPath = join(tempPackagePath, 'bin', 'direflow-scripts');
+    const tempCliPath = join(tempPackagePath, 'dist', 'cli.js');
+
+    mkdirSync(join(tempPackagePath, 'bin'), { recursive: true });
+    mkdirSync(join(tempPackagePath, 'dist'), { recursive: true });
+    writeFileSync(tempBinPath, readFileSync(binPath, 'utf8'));
+    writeFileSync(tempCliPath, 'exports.default = () => {};\n');
+
+    const result = spawnSync(process.execPath, [tempBinPath, '--help'], {
       encoding: 'utf8',
     });
+
+    rmSync(tempPackagePath, { recursive: true, force: true });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');


### PR DESCRIPTION
## Summary

Closes #6.

This PR fixes the published `@kefelan/direflow-scripts` bin launcher so it works on modern Node runtimes without relying on `esm`, and updates GitHub Actions validation to current modern Node versions.

The package was already compiling `dist/cli.js` as CommonJS, but the published bin still bootstrapped through `esm@3.2.25`. That extra bootstrap path was the failing part on Node 22/24.

This change switches the bin launcher to direct CommonJS loading, removes the unnecessary `esm` dependency from `@kefelan/direflow-scripts`, fixes a CI regression in the new bin test, updates GitHub Actions validation to modern Node versions, and bumps the coordinated package versions to `5.0.3`.

## What changed

### `@kefelan/direflow-scripts` bin launcher

- updates `packages/direflow-scripts/bin/direflow-scripts`
- removes the `require('esm')(module)` bootstrap
- loads `../dist/cli` directly as CommonJS
- preserves the existing CLI invocation flow via `process.argv.slice(2)`

### Package dependencies

- removes `esm` from `packages/direflow-scripts/package.json`
- refreshes `packages/direflow-scripts/package-lock.json`

### Regression coverage

- adds `test/direflowScriptsBin.test.ts`
- verifies the launcher no longer references `esm`
- verifies the bin can be invoked through `node` without crashing

### CI-safe regression test adjustment

- fixes the `.github/workflows/build.yml` failure caused by the first version of the regression test
- avoids assuming that `packages/direflow-scripts/dist/cli.js` already exists in a fresh checkout
- keeps the test focused on the real tracked bin file, but executes it from a temporary package-shaped directory with a stub `dist/cli.js`
- preserves the intent of the test while making it reliable before any package build step runs

### GitHub Actions workflow updates

- updates `.github/workflows/build.yml` to validate on a Node `22` / `24` matrix
- updates `.github/workflows/publish.yml` `validate` job to validate on a Node `22` / `24` matrix
- updates `.github/workflows/publish.yml` `prepare` job from Node `20` to Node `24`
- keeps npm publishing jobs on Node `24`

### Coordinated release versioning

- bumps the three publishable packages to `5.0.3`:
  - `@kefelan/direflow-cli`
  - `@kefelan/direflow-component`
  - `@kefelan/direflow-scripts`
- updates template package references to `5.0.3`
- refreshes the root and package lockfiles after the coordinated version bump

## Why this matters

- fixes a real runtime compatibility issue for the published `direflow-scripts` bin on Node 22/24
- removes an unnecessary dependency from the package entry path
- keeps the package aligned with its actual build output format (`CommonJS`)
- fixes a CI-only failure mode introduced by testing the launcher against untracked build artifacts
- makes the regression test deterministic on fresh GitHub Actions checkouts
- removes remaining Node 20 dependency from the repository’s active GitHub Actions paths
- aligns validation with currently relevant modern Node runtimes by testing on both Node 22 and Node 24
- keeps publishing on Node 24 while expanding validation coverage across the two modern lines we care about
- ships the fix as a patch-level coordinated release

## Validation

### Node 20.19.2

- `fnm exec --using 20.19.2 npm test -- --runInBand test/direflowScriptsBin.test.ts`
- `fnm exec --using 20.19.2 npm test -- --runInBand`

### Node 24

- `node packages/direflow-scripts/bin/direflow-scripts --help`
- `npm test -- --runInBand test/direflowScriptsBin.test.ts`
- `cd packages/direflow-scripts && npm pack --dry-run`

### Node 22.22.2

- `fnm exec --using 22.22.2 node packages/direflow-scripts/bin/direflow-scripts --help`
- `fnm exec --using 22.22.2 npm test -- --runInBand test/direflowScriptsBin.test.ts`
- `cd packages/direflow-scripts && fnm exec --using 22.22.2 npm pack --dry-run`

### Workflow files

- parsed `.github/workflows/build.yml` successfully
- parsed `.github/workflows/publish.yml` successfully

All of the above passed locally.

## Release impact

This should be released as coordinated patch version `5.0.3`.